### PR TITLE
Use recursion to inflate

### DIFF
--- a/src/balloon/core.clj
+++ b/src/balloon/core.clj
@@ -122,12 +122,30 @@
                       m
                       (let [k (first ks)
                             v (get m k)]
-                        (if (map? v)
+                        (cond
+                          (map? v)
                           (if (deflated? k)
                             (inf-recur (rest ks)
                                        (assoc-x (dissoc m k) (convert k) (inf-recur (keys v) v)))
                             (inf-recur (rest ks)
-                                       {k (inf-recur (keys v) v)}))
+                                       (assoc m k (inf-recur (keys v) v))))
+
+                          (sequential? v)
+                          (if (deflated? k)
+                            (inf-recur (rest ks)
+                                       (assoc-x (dissoc m k) (convert k) (vec (map (fn [sv]
+                                                                                     (if (map? sv)
+                                                                                       (inf-recur (keys sv) sv)
+                                                                                       sv))
+                                                                                   v))))
+                            (inf-recur (rest ks)
+                                       (assoc m k (vec (map (fn [sv]
+                                                              (if (map? sv)
+                                                                (inf-recur (keys sv) sv)
+                                                                sv))
+                                                            v)))))
+
+                          :else
                           (if (deflated? k)
                             (inf-recur (rest ks)
                                        (assoc-x (dissoc m k) (convert k) v))

--- a/src/balloon/core.clj
+++ b/src/balloon/core.clj
@@ -107,9 +107,8 @@
   "Unflats a one level deep flat map to a nested one.
 
   Options are key-value pairs and may be one or many of:
-  :delimiter   - Use different delimiter to unflat the hash-map delimited keys, defaults to .
-  :pre-deflate - Run deflate on hash-map to guarantee is fully normalized before running unflat process, defaults to true
-  :hash-map    - Unflat indexes in delimited keys as hash-map, not as a collection, defaults to false"
+  :delimiter   - Use different delimiter to unflat the hash-map delimited keys, defaults to '.'
+  :hash-map    - Unflat indexes/numbers in delimited keys as hash-maps, not as collections, defaults to false"
   [m & {:keys [delimiter hash-map]
         :or {delimiter "."
              hash-map false}}]

--- a/src/balloon/core.clj
+++ b/src/balloon/core.clj
@@ -149,3 +149,31 @@
          (assoc acc k v)))
      {}
      dm)))
+
+(defn construct-recur [m ks v]
+  (if (= (count ks) 1)
+    (assoc m (first ks) v)
+    (let [k  (first ks)
+          mv (get m k)]
+      (if (map? mv)
+        (assoc m
+               k
+               (construct-recur mv (rest ks) v))
+        (assoc m
+               k
+               (construct-recur {} (rest ks) v))))))
+
+(defn inflate-recur [ks m]
+  (if (empty? ks)
+    m
+    (let [k (first ks)
+          v (get m k)]
+      (if (map? v)
+        (let [val (inflate-recur (keys v) v)]
+          (if ((deflated-key? ".") k)
+            (construct-recur (dissoc m k) ((deflated-key->path ".") k) val)
+            {k val}))
+        (if ((deflated-key? ".") k)
+          (inflate-recur (rest ks)
+                         (construct-recur (dissoc m k) ((deflated-key->path ".") k) v))
+          (inflate-recur (rest ks) m))))))

--- a/src/balloon/core.clj
+++ b/src/balloon/core.clj
@@ -126,28 +126,30 @@
                           (map? v)
                           (if (deflated? k)
                             (inf-recur (rest ks)
-                                       (assoc-x (dissoc m k) (convert k) (inf-recur (keys v) v)))
+                                       (assoc-x (dissoc m k)
+                                                (convert k)
+                                                (inf-recur (keys v) v)))
                             (inf-recur (rest ks)
                                        (assoc m k (inf-recur (keys v) v))))
 
                           (sequential? v)
-                          (if (deflated? k)
-                            (inf-recur (rest ks)
-                                       (assoc-x (dissoc m k) (convert k) (vec (map (fn [sv]
-                                                                                     (if (map? sv)
-                                                                                       (inf-recur (keys sv) sv)
-                                                                                       sv))
-                                                                                   v))))
-                            (inf-recur (rest ks)
-                                       (assoc m k (vec (map (fn [sv]
-                                                              (if (map? sv)
-                                                                (inf-recur (keys sv) sv)
-                                                                sv))
-                                                            v)))))
+                          (let [map-fn (fn [sv]
+                                         (if (map? sv)
+                                           (inf-recur (keys sv) sv)
+                                           sv))]
+                            (if (deflated? k)
+                              (inf-recur (rest ks)
+                                         (assoc-x (dissoc m k)
+                                                  (convert k)
+                                                  (vec (map map-fn v))))
+                              (inf-recur (rest ks)
+                                         (assoc m k (vec (map map-fn v))))))
 
                           :else
                           (if (deflated? k)
                             (inf-recur (rest ks)
-                                       (assoc-x (dissoc m k) (convert k) v))
+                                       (assoc-x (dissoc m k)
+                                                (convert k)
+                                                v))
                             (inf-recur (rest ks) m))))))]
     (inf-recur (keys m) m)))

--- a/src/balloon/core.clj
+++ b/src/balloon/core.clj
@@ -150,18 +150,18 @@
      {}
      dm)))
 
-(defn construct-recur [m ks v]
-  (if (= (count ks) 1)
-    (assoc m (first ks) v)
-    (let [k  (first ks)
+(defn construct-recur [m path v]
+  (if (= (count path) 1)
+    (assoc m (first path) v)
+    (let [k  (first path)
           mv (get m k)]
       (if (map? mv)
         (assoc m
                k
-               (construct-recur mv (rest ks) v))
+               (construct-recur mv (rest path) v))
         (assoc m
                k
-               (construct-recur {} (rest ks) v))))))
+               (construct-recur {} (rest path) v))))))
 
 (defn inflate-recur [ks m]
   (if (empty? ks)

--- a/src/balloon/core.clj
+++ b/src/balloon/core.clj
@@ -169,10 +169,9 @@
     (let [k (first ks)
           v (get m k)]
       (if (map? v)
-        (let [val (inflate-recur (keys v) v)]
-          (if ((deflated-key? ".") k)
-            (construct-recur (dissoc m k) ((deflated-key->path ".") k) val)
-            {k val}))
+        (if ((deflated-key? ".") k)
+          (construct-recur (dissoc m k) ((deflated-key->path ".") k) (inflate-recur (keys v) v))
+          {k (inflate-recur (keys v) v)})
         (if ((deflated-key? ".") k)
           (inflate-recur (rest ks)
                          (construct-recur (dissoc m k) ((deflated-key->path ".") k) v))

--- a/src/balloon/core.clj
+++ b/src/balloon/core.clj
@@ -124,12 +124,11 @@
                             v (get m k)]
                         (cond
                           (map? v)
-                          (if (deflated? k)
-                            (inf-recur (rest ks)
+                          (inf-recur (rest ks)
+                                     (if (deflated? k)
                                        (assoc-x (dissoc m k)
                                                 (convert k)
-                                                (inf-recur (keys v) v)))
-                            (inf-recur (rest ks)
+                                                (inf-recur (keys v) v))
                                        (assoc m k (inf-recur (keys v) v))))
 
                           (sequential? v)
@@ -142,19 +141,18 @@
                                            (vec (map map-fn sv))
 
                                            :else sv))]
-                            (if (deflated? k)
-                              (inf-recur (rest ks)
+                            (inf-recur (rest ks)
+                                       (if (deflated? k)
                                          (assoc-x (dissoc m k)
                                                   (convert k)
-                                                  (vec (map map-fn v))))
-                              (inf-recur (rest ks)
+                                                  (vec (map map-fn v)))
                                          (assoc m k (vec (map map-fn v))))))
 
                           :else
-                          (if (deflated? k)
-                            (inf-recur (rest ks)
+                          (inf-recur (rest ks)
+                                     (if (deflated? k)
                                        (assoc-x (dissoc m k)
                                                 (convert k)
-                                                v))
-                            (inf-recur (rest ks) m))))))]
+                                                v)
+                                       m))))))]
     (inf-recur (keys m) m)))

--- a/src/balloon/core.clj
+++ b/src/balloon/core.clj
@@ -86,7 +86,12 @@
           (string/split (name k)
                         (re-pattern (java.util.regex.Pattern/quote delimiter)))))))
 
-(defn- assoc-inth [form path v]
+(defn- assoc-inth
+  "Like assoc-in but conjoins value to a vector if key in path is a number.
+  Eg:
+  (assoc-in {} [:a 0] 1) => {:a {0 1}}
+  (assoc-inth {} [:a 0] 1) => {:a [1]}"
+  [form path v]
   (let [result (reduce
                 (fn [{:keys [end-path end-form] :as acc} k]
                   (if (keyword? k)

--- a/src/balloon/core.clj
+++ b/src/balloon/core.clj
@@ -133,10 +133,15 @@
                                        (assoc m k (inf-recur (keys v) v))))
 
                           (sequential? v)
-                          (let [map-fn (fn [sv]
-                                         (if (map? sv)
+                          (let [map-fn (fn map-fn [sv]
+                                         (cond
+                                           (map? sv)
                                            (inf-recur (keys sv) sv)
-                                           sv))]
+
+                                           (sequential? sv)
+                                           (vec (map map-fn sv))
+
+                                           :else sv))]
                             (if (deflated? k)
                               (inf-recur (rest ks)
                                          (assoc-x (dissoc m k)

--- a/test/balloon/core_test.clj
+++ b/test/balloon/core_test.clj
@@ -41,16 +41,24 @@
          (let [result (b/inflate (:deflated* item) :delimiter "*")]
            (is (= result (:inflated item))))))))
 
-  (testing "Inflating maps using :pre-deflate false"
-    (let [value {:value {:a.b "a.b"}
-                 :other.0 "any"}
-          result (b/inflate value :pre-deflate false)]
-      (is (= result {:value {:a.b "a.b"}
-                     :other ["any"]}))))
-
   (testing "Inflating maps using :hash-map true"
     (let [value {:value ["a" "b" "c"]
                  :other.0 "any"}
           result (b/inflate value :hash-map true)]
-      (is (= result {:value {0 "a" 1 "b" 2 "c"}
-                     :other {0 "any"}})))))
+      (is (= result {:value ["a" "b" "c"]
+                     :other {0 "any"}}))))
+
+  (testing "Inflating maps using :hash-map true (again)"
+    (let [value {:my-map.one "one",
+                 :my-map.two "two",
+                 :my-map.any.other "other",
+                 :my-map.any.arr [{:a.b "c"}]
+                 :my-array.0.a "a",
+                 :my-array.1 "b",
+                 :my-array.2 "c"}
+          result (b/inflate value :hash-map true)]
+      (is (= result {:my-map {:one "one",
+                              :two "two",
+                              :any {:other "other"}
+                              :arr [{:a {:b "c"}}]},
+                     :my-array {0 {:a "a"} 1 "b" 2 "c"}})))))

--- a/test/balloon/core_test.clj
+++ b/test/balloon/core_test.clj
@@ -62,4 +62,28 @@
                       :two "two",
                       :any {:other "other",
                             :arr [{:a {:b "c"}}]}},
-                     :my-array {0 {:a "a"}, 1 "b", 2 "c"}})))))
+                     :my-array {0 {:a "a"}, 1 "b", 2 "c"}}))))
+
+  (testing "Inflating maps with sequentials with maps"
+    (let [value {:my-map.one "one",
+                 :my-map.any.arr [{:a.b "c"}
+                                  {:c [{:d.f [{:g.j "j"}]}]}]
+                 :my-array.0.a "a",
+                 :my-array.1 "b",
+                 :my-array.2 "c"}
+          result (b/inflate value :hash-map true)]
+      (is (= result {:my-map
+                     {:one "one",
+                      :any {:arr [{:a {:b "c"}}
+                                  {:c [{:d {:f [{:g {:j "j"}}]}}]}]}},
+                     :my-array {0 {:a "a"}, 1 "b", 2 "c"}}))))
+
+  (testing "Inflating maps with nested sequentials"
+    (let [value {:my-map.one "one",
+                 :my-map.any.arr [[{:a.b "c"}]
+                                  {:c [{:d.f [[{:g.j "j"}]]}]}]}
+          result (b/inflate value :hash-map true)]
+      (is (= result {:my-map
+                     {:one "one",
+                      :any {:arr [[{:a {:b "c"}}]
+                                  {:c [{:d {:f [[{:g {:j "j"}}]]}}]}]}},})))))

--- a/test/balloon/core_test.clj
+++ b/test/balloon/core_test.clj
@@ -57,8 +57,9 @@
                  :my-array.1 "b",
                  :my-array.2 "c"}
           result (b/inflate value :hash-map true)]
-      (is (= result {:my-map {:one "one",
-                              :two "two",
-                              :any {:other "other"}
-                              :arr [{:a {:b "c"}}]},
-                     :my-array {0 {:a "a"} 1 "b" 2 "c"}})))))
+      (is (= result {:my-map
+                     {:one "one",
+                      :two "two",
+                      :any {:other "other",
+                            :arr [{:a {:b "c"}}]}},
+                     :my-array {0 {:a "a"}, 1 "b", 2 "c"}})))))


### PR DESCRIPTION
Re-implement inflate using recursion to make it cleaner and to avoid pre deflating map before inflating it again which can incur in unwanted results. Example:

```clj
(def test-m {:value ["a" "b" "c"]
             :other.0 "any"})

;; Before
(inflate test-m :hash-map true) ;;=> {:value {0 "a", 1 "b", 2 "c"}, :other {0 "any"}}

;; Now
(inflate test-m :hash-map true) ;;=> {:value ["a" "b" "c"], :other {0 "any"}}
```